### PR TITLE
chore(psalm): Add psalm for static analysis

### DIFF
--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -1,0 +1,40 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Lint php-cs
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-php-cs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    name: php-cs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up php
+        uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
+        with:
+          php-version: 8.1
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer i
+
+      - name: Lint
+        run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,42 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Static analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+      - stable*
+
+concurrency:
+  group: psalm-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    name: Nextcloud
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Set up php
+        uses: shivammathur/setup-php@2.25.5 # v2
+        with:
+          php-version: 8.1
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer i
+
+      - name: Run coding standards check
+        run: composer run psalm

--- a/lib/Listener/TokenObtainedEventListener.php
+++ b/lib/Listener/TokenObtainedEventListener.php
@@ -34,6 +34,7 @@ use OCP\Http\Client\IClientService;
 use Psr\Log\LoggerInterface;
 use OCP\Security\ICrypto;
 
+/** @template-implements IEventListener<TokenObtainedEvent|Event> */
 class TokenObtainedEventListener implements IEventListener {
 	private IClientService $clientService;
 	private TokenService $tokenService;
@@ -83,7 +84,7 @@ class TokenObtainedEventListener implements IEventListener {
 				]
 			);
 
-			$tokenData = json_decode($result->getBody(), true);
+			$tokenData = json_decode((string)$result->getBody(), true);
 
 			$this->tokenService->storeToken(array_merge($tokenData, ['provider_id' => $provider->getId()]));
 

--- a/lib/Listener/TokenObtainedEventListener.php
+++ b/lib/Listener/TokenObtainedEventListener.php
@@ -31,8 +31,8 @@ use OCA\UserOIDC\Event\TokenObtainedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Http\Client\IClientService;
-use Psr\Log\LoggerInterface;
 use OCP\Security\ICrypto;
+use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<TokenObtainedEvent|Event> */
 class TokenObtainedEventListener implements IEventListener {
@@ -40,18 +40,18 @@ class TokenObtainedEventListener implements IEventListener {
 	private TokenService $tokenService;
 	private SpicaMailService $mailService;
 	private LoggerInterface $logger;
-	private ICrypto $crypt;
+	private ICrypto $crypto;
 
-	public function __construct(IClientService $clientService, 
-            TokenService $tokenService, 
-            SpicaMailService $mailService, 
-            LoggerInterface $logger,
-            ICrypto $crypto) {
+	public function __construct(IClientService $clientService,
+		TokenService $tokenService,
+		SpicaMailService $mailService,
+		LoggerInterface $logger,
+		ICrypto $crypto) {
 		$this->clientService = $clientService;
 		$this->tokenService = $tokenService;
 		$this->mailService = $mailService;
 		$this->logger = $logger;
-        $this->crypto = $crypto;
+		$this->crypto = $crypto;
 	}
 
 	public function handle(Event $event): void {
@@ -91,12 +91,12 @@ class TokenObtainedEventListener implements IEventListener {
 			$this->mailService->resetCache();
 			$this->mailService->fetchUnreadCounter();
 		} catch (\Throwable $e) {
-            if (str_starts_with(get_class($e), 'PHPUnit')) {
-                // to keep unit test assertions enabled
-                throw $e;
-            }
+			if (str_starts_with(get_class($e), 'PHPUnit')) {
+				// to keep unit test assertions enabled
+				throw $e;
+			}
 
-            // Only log exceptions but do not block login
+			// Only log exceptions but do not block login
 			$this->logger->error('Failed to handle oidc token for spica initialization', ['exception' => $e]);
 		}
 	}

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -69,7 +69,7 @@ class Token implements JsonSerializable {
 		return $this->refreshToken;
 	}
 
-	public function getProviderId(): int {
+	public function getProviderId(): ?int {
 		return $this->providerId;
 	}
 

--- a/lib/Service/SpicaBaseService.php
+++ b/lib/Service/SpicaBaseService.php
@@ -26,11 +26,14 @@ namespace OCA\NmcSpica\Service;
 use OCA\NmcSpica\AppInfo\Application;
 use OCA\NmcSpica\ServiceException;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 
 class SpicaBaseService {
 
 	/** @var IConfig */
 	private $config;
+	/** @var LoggerInterface */
+	private $logger;
 	/** @var TokenService */
 	private $tokenService;
 	/** @var string|null */
@@ -40,8 +43,9 @@ class SpicaBaseService {
 	private $spicaAppId;
 	private $spicaAppSecret;
 
-	public function __construct(IConfig $config, TokenService $tokenService, $userId) {
+	public function __construct(IConfig $config, LoggerInterface $logger, TokenService $tokenService, ?string $userId) {
 		$this->config = $config;
+		$this->logger = $logger;
 		$this->tokenService = $tokenService;
 		$this->userId = $userId;
 		if ($userId === null) {

--- a/lib/Service/SpicaContactsService.php
+++ b/lib/Service/SpicaContactsService.php
@@ -40,8 +40,8 @@ class SpicaContactsService extends SpicaBaseService {
 	/** @var string|null */
 	private $userId;
 
-	public function __construct(IConfig $config, TokenService $tokenService, IClientService $clientService, LoggerInterface $logger, $userId) {
-		parent::__construct($config, $tokenService, $userId);
+	public function __construct(IConfig $config, TokenService $tokenService, IClientService $clientService, LoggerInterface $logger, ?string $userId) {
+		parent::__construct($config, $logger, $tokenService, $userId);
 		$this->clientService = $clientService;
 		$this->logger = $logger;
 		$this->userId = $userId;

--- a/lib/Service/SpicaMailService.php
+++ b/lib/Service/SpicaMailService.php
@@ -47,8 +47,8 @@ class SpicaMailService extends SpicaBaseService {
 	/** @var string|null */
 	private $userId;
 
-	public function __construct(IConfig $config, IClientService $clientService, LoggerInterface $logger, TokenService $tokenService, ICacheFactory $cacheFactory, $userId) {
-		parent::__construct($config, $tokenService, $userId);
+	public function __construct(IConfig $config, IClientService $clientService, LoggerInterface $logger, TokenService $tokenService, ICacheFactory $cacheFactory, ?string $userId) {
+		parent::__construct($config, $logger, $tokenService, $userId);
 		$this->config = $config;
 		$this->clientService = $clientService;
 		$this->logger = $logger;
@@ -92,7 +92,7 @@ class SpicaMailService extends SpicaBaseService {
 
 	public function setUnreadCounter(int $counter): void {
 		$this->cache->set($this->userId, $counter,
-			$this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_CACHE_TTL_MAIL, Application::APP_CONFIG_CACHE_TTL_MAIL_DEFAULT)
+			(int)$this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_CACHE_TTL_MAIL, (string)Application::APP_CONFIG_CACHE_TTL_MAIL_DEFAULT)
 		);
 		$this->config->setUserValue($this->userId, Application::APP_ID, Application::USER_CONFIG_KEY_UNREAD_COUNT, (string)$counter);
 	}

--- a/lib/SpicaAddressBook.php
+++ b/lib/SpicaAddressBook.php
@@ -100,7 +100,7 @@ class SpicaAddressBook implements IAddressBook {
 			return [];
 		}
 		// form the result set
-		$result = array_merge(...array_map(static function ($contact) {
+		$result = array_merge(...array_values(array_map(static function ($contact) {
 			$emails = $contact['emails'] ?? [];
 			$template = ['UID' => ($contact['first'] ?? '') . ' ' . ($contact['last'] ?? ''),'FN' => ($contact['first'] ?? '') . ' ' . ($contact['last'] ?? '') ];
 			if (empty($emails)) {
@@ -109,10 +109,10 @@ class SpicaAddressBook implements IAddressBook {
 			return array_map(static function ($email) use ($template) {
 				return array_merge($template, ['EMAIL' => $email['email'], 'UID' => $email['email']]);
 			}, $emails);
-		}, $contacts));
+		}, $contacts)));
 
 		$this->cache->set($cacheKey, $result,
-			$this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_CACHE_TTL_CONTACTS, Application::APP_CONFIG_CACHE_TTL_CONTACTS_DEFAULT)
+			(int)$this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_CACHE_TTL_CONTACTS, (string)Application::APP_CONFIG_CACHE_TTL_CONTACTS_DEFAULT)
 		);
 
 		return $result;

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<psalm
+		errorLevel="4"
+		resolveFromConfigFile="true"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="https://getpsalm.org/schema/config"
+		xsi:schemaLocation="https://getpsalm.org/schema/config"
+		errorBaseline="tests/psalm-baseline.xml"
+>
+	<stubs>
+		<file name="tests/stub.phpstub" preloadClasses="true"/>
+	</stubs>
+	<projectFiles>
+		<directory name="lib" />
+		<ignoreFiles>
+			<directory name="vendor" />
+		</ignoreFiles>
+	</projectFiles>
+	<extraFiles>
+		<directory name="vendor" />
+	</extraFiles>
+	<issueHandlers>
+		<UndefinedMagicMethod>
+			<errorLevel type="suppress">
+				<referencedMethod name="/Db\\.*::.*/" />
+			</errorLevel>
+		</UndefinedMagicMethod>
+		<UndefinedInterfaceMethod>
+			<errorLevel type="suppress">
+				<!-- FIXME Deprecated event handling -->
+				<referencedMethod name="OCP\IUserManager::listen" />
+				<referencedMethod name="OCP\IGroupManager::listen" />
+			</errorLevel>
+		</UndefinedInterfaceMethod>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OC\*" />
+				<referencedClass name="OC" />
+				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
+				<referencedClass name="Symfony\Component\Console\Command\Command" />
+				<referencedClass name="Symfony\Component\Console\Question\ChoiceQuestion" />
+				<referencedClass name="Symfony\Component\Console\Question\Question" />
+				<referencedClass name="Symfony\Component\EventDispatcher\GenericEvent" />
+			</errorLevel>
+		</UndefinedClass>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OC\*" />
+				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
+				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
+				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
+				<referencedClass name="Doctrine\DBAL\Schema\Table" />
+				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
+				<referencedClass name="Symfony\Component\Console\Command\Command" />
+			</errorLevel>
+		</UndefinedDocblockClass>
+	</issueHandlers>
+</psalm>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+</files>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -8,3 +8,10 @@ namespace OCA\UserOIDC\Db {
 	class ProviderMapper {}
 }
 
+namespace OCA\UserOIDC\Event {
+	abstract class TokenObtainedEvent extends \OCP\EventDispatcher\Event {
+		public function getToken();
+		public function getProvider();
+		public function getDiscovery();
+	}
+}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -1,0 +1,10 @@
+<?php
+
+namespace OCA\UserOIDC\Db {
+	abstract class Provider {
+		public function getId();
+		 public function getDiscoveryEndpoint(): string;
+	}
+	class ProviderMapper {}
+}
+

--- a/tests/unit/TokenCryptoTest.php
+++ b/tests/unit/TokenCryptoTest.php
@@ -1,173 +1,170 @@
 <?php
 
-use OCA\UserOIDC\Db\User;
-use OCP\Security\ICrypto;
-
 use OCA\NmcSpica\Listener\TokenObtainedEventListener;
+
 use OCA\NmcSpica\Service\SpicaMailService;
 use OCA\NmcSpica\Service\TokenService;
 use OCA\UserOIDC\Db\Provider;
 use OCA\UserOIDC\Event\TokenObtainedEvent;
-use OCP\Http\Client\IClientService;
-use OCP\Http\Client\IClient;
-use OCP\Http\Client\IResponse;
-use Psr\Log\LoggerInterface;
-
 use OCP\AppFramework\App;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\Security\ICrypto;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
+use Psr\Log\LoggerInterface;
 
 /**
  * Test refresh token handling for different situations
  */
 class TokenCryptoTest extends TestCase {
-    private SpicaMailService $mailService;
-    private TokenService $tokenService;
-    private IClient $client;
-    private TokenObtainedEventListener $listener;
-    private ICrypto $crypt;
-    private LoggerInterface $logger;
+	private SpicaMailService $mailService;
+	private TokenService $tokenService;
+	private IClient $client;
+	private TokenObtainedEventListener $listener;
+	private ICrypto $crypt;
+	private LoggerInterface $logger;
 
 
-    private Provider $provider;
+	private Provider $provider;
 
 
 	public function setUp(): void {
 		parent::setUp();
 
-        $this->app = new App("nmc_spica");
-        $this->crypto = $this->app->getContainer()->get(ICrypto::class);
-        $this->tokenService = $this->createMock(TokenService::class);
-        $this->mailService = $this->createMock(SpicaMailService::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+		$this->app = new App("nmc_spica");
+		$this->crypto = $this->app->getContainer()->get(ICrypto::class);
+		$this->tokenService = $this->createMock(TokenService::class);
+		$this->mailService = $this->createMock(SpicaMailService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
-        $clientService = $this->createMock(IClientService::class);
-        $this->client = $this->createMock(IClient::class);
-        $clientService->expects(self::any())
-            ->method('newClient')
-            ->willReturn($this->client);
- 
-
-        $this->provider = $this->getMockBuilder(Provider::class)
-            ->addMethods(['getClientId', 'getCLientSecret'])
-            ->getMock();
-        $this->provider->expects(self::any())
-            ->method('getClientId')
-            ->willReturn('CLIENT0001T23456');
-        $this->provider->expects(self::any())
-            ->method('getClientSecret')
-            ->willReturn($this->crypto->encrypt("Th1iIs_Vry\$ectre"));
-
-        $this->listener = new TokenObtainedEventListener(
-            $clientService,
-            $this->tokenService,
-            $this->mailService,
-            $this->logger,
-            $this->crypto
-        );
-    }
+		$clientService = $this->createMock(IClientService::class);
+		$this->client = $this->createMock(IClient::class);
+		$clientService->expects(self::any())
+			->method('newClient')
+			->willReturn($this->client);
 
 
-    /**
-     * Test whether client secret is properly decrypted
-     */
-    public function testClientSecretDecrpyt() {
-       $tokenResponse = $this->createMock(IResponse::class);
-       $tokenResponse->expects(self::any())
-            ->method('getBody')
-            ->willReturn(json_encode([
-                'access_token' => "eyJwMnMiOiI3...",
-            ]));
-        $tokenResponse->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $this->client->expects(self::once())
-            ->method('post')
-            ->with(
-                $this->equalTo("https://provider.my/token"),
-                $this->callback(function(array $message): bool {
-                    $this->assertArrayHasKey('body', $message);
-                    $body = $message['body'];
-                    $this->assertEquals($body['scope'], 'spica');
-                    $this->assertEquals($body['grant_type'], 'refresh_token');
-                    $this->assertEquals($body['client_id'], 'CLIENT0001T23456');
-                    $this->assertEquals($body['client_secret'], "Th1iIs_Vry\$ectre");
-                    return true; 
-                }))
-            ->willReturn($tokenResponse);
-        $this->tokenService->expects(self::once())
-            ->method('storeToken')
-            ->with($this->logicalAnd( $this->arrayHasKey('access_token'), 
-                    $this->arrayHasKey('provider_id')));
-        $this->mailService->expects(self::once())
-            ->method('resetCache');
-        $this->mailService->expects(self::once())
-            ->method('fetchUnreadCounter');
-        $this->logger->expects(self::never())
-            ->method('error');
+		$this->provider = $this->getMockBuilder(Provider::class)
+			->addMethods(['getClientId', 'getCLientSecret'])
+			->getMock();
+		$this->provider->expects(self::any())
+			->method('getClientId')
+			->willReturn('CLIENT0001T23456');
+		$this->provider->expects(self::any())
+			->method('getClientSecret')
+			->willReturn($this->crypto->encrypt("Th1iIs_Vry\$ectre"));
 
-        $event = new TokenObtainedEvent([
-            'refresh_token' => "RT2:5157ed22-d2d3-421a-b5ec-371dc540f200:848234d1-3fb8-4f73-a971-fe3968f2e266",
-            'access_token' => "<dummy>",
-            'scope' => "userinfo",
-            'token_type' => "Bearer"
-        ], $this->provider, [
-            'token_endpoint' => "https://provider.my/token"
-        ]);
+		$this->listener = new TokenObtainedEventListener(
+			$clientService,
+			$this->tokenService,
+			$this->mailService,
+			$this->logger,
+			$this->crypto
+		);
+	}
 
-        $this->listener->handle($event);
-    }
 
-    public function testNoRefreshToken() {
-        $this->client->expects(self::never())
-            ->method('post');
-        $this->tokenService->expects(self::never())
-            ->method('storeToken');
-        $this->mailService->expects(self::never())
-            ->method('resetCache');
-        $this->mailService->expects(self::never())
-            ->method('fetchUnreadCounter');
-        $this->logger->expects(self::never())
-            ->method('error');
+	/**
+	 * Test whether client secret is properly decrypted
+	 */
+	public function testClientSecretDecrpyt() {
+		$tokenResponse = $this->createMock(IResponse::class);
+		$tokenResponse->expects(self::any())
+			->method('getBody')
+			->willReturn(json_encode([
+				'access_token' => "eyJwMnMiOiI3...",
+			]));
+		$tokenResponse->expects(self::any())
+			->method('getStatusCode')
+			->willReturn(200);
+		$this->client->expects(self::once())
+			->method('post')
+			->with(
+				$this->equalTo("https://provider.my/token"),
+				$this->callback(function (array $message): bool {
+					$this->assertArrayHasKey('body', $message);
+					$body = $message['body'];
+					$this->assertEquals($body['scope'], 'spica');
+					$this->assertEquals($body['grant_type'], 'refresh_token');
+					$this->assertEquals($body['client_id'], 'CLIENT0001T23456');
+					$this->assertEquals($body['client_secret'], "Th1iIs_Vry\$ectre");
+					return true;
+				}))
+			->willReturn($tokenResponse);
+		$this->tokenService->expects(self::once())
+			->method('storeToken')
+			->with($this->logicalAnd($this->arrayHasKey('access_token'),
+				$this->arrayHasKey('provider_id')));
+		$this->mailService->expects(self::once())
+			->method('resetCache');
+		$this->mailService->expects(self::once())
+			->method('fetchUnreadCounter');
+		$this->logger->expects(self::never())
+			->method('error');
 
-        $event = new TokenObtainedEvent([
-            'access_token' => "<dummy>",
-            'scope' => "userinfo",
-            'token_type' => "Bearer"
-        ], $this->provider, [
-            'token_endpoint' => "https://provider.my/token"
-        ]);
-    
-        $this->listener->handle($event);
-    }
+		$event = new TokenObtainedEvent([
+			'refresh_token' => "RT2:5157ed22-d2d3-421a-b5ec-371dc540f200:848234d1-3fb8-4f73-a971-fe3968f2e266",
+			'access_token' => "<dummy>",
+			'scope' => "userinfo",
+			'token_type' => "Bearer"
+		], $this->provider, [
+			'token_endpoint' => "https://provider.my/token"
+		]);
 
-    public function testTokenServiceError() {
-        $this->client->expects(self::once())
-            ->method('post')
-            ->will($this->throwException(new \TypeError("Unexpected test type")));
-        $this->tokenService->expects(self::never())
-            ->method('storeToken');
-        $this->mailService->expects(self::never())
-            ->method('resetCache');
-        $this->mailService->expects(self::never())
-            ->method('fetchUnreadCounter');
-        $this->logger->expects(self::once())
-            ->method('error')
-            ->with($this->stringContains('oidc token'));
-            
-            $event = new TokenObtainedEvent([
-                'refresh_token' => "RT2:5157ed22-d2d3-421a-b5ec-371dc540f200:848234d1-3fb8-4f73-a971-fe3968f2e266",
-                'access_token' => "<dummy>",
-                'scope' => "userinfo",
-                'token_type' => "Bearer"
-            ], $this->provider, [
-                'token_endpoint' => "https://provider.my/token"
-            ]);
-    
-            $this->listener->handle($event);    
-    }
+		$this->listener->handle($event);
+	}
+
+	public function testNoRefreshToken() {
+		$this->client->expects(self::never())
+			->method('post');
+		$this->tokenService->expects(self::never())
+			->method('storeToken');
+		$this->mailService->expects(self::never())
+			->method('resetCache');
+		$this->mailService->expects(self::never())
+			->method('fetchUnreadCounter');
+		$this->logger->expects(self::never())
+			->method('error');
+
+		$event = new TokenObtainedEvent([
+			'access_token' => "<dummy>",
+			'scope' => "userinfo",
+			'token_type' => "Bearer"
+		], $this->provider, [
+			'token_endpoint' => "https://provider.my/token"
+		]);
+
+		$this->listener->handle($event);
+	}
+
+	public function testTokenServiceError() {
+		$this->client->expects(self::once())
+			->method('post')
+			->will($this->throwException(new \TypeError("Unexpected test type")));
+		$this->tokenService->expects(self::never())
+			->method('storeToken');
+		$this->mailService->expects(self::never())
+			->method('resetCache');
+		$this->mailService->expects(self::never())
+			->method('fetchUnreadCounter');
+		$this->logger->expects(self::once())
+			->method('error')
+			->with($this->stringContains('oidc token'));
+
+		$event = new TokenObtainedEvent([
+			'refresh_token' => "RT2:5157ed22-d2d3-421a-b5ec-371dc540f200:848234d1-3fb8-4f73-a971-fe3968f2e266",
+			'access_token' => "<dummy>",
+			'scope' => "userinfo",
+			'token_type' => "Bearer"
+		], $this->provider, [
+			'token_endpoint' => "https://provider.my/token"
+		]);
+
+		$this->listener->handle($event);
+	}
 
 
 }


### PR DESCRIPTION
Might be nice to at some point pull in the classes directly from user_oidc instead of having stubs since there is deeper integration, but at least covers the rest already.

In addition adding php-cs-fixer to CI and fixing code style and drop trailing whitespaces